### PR TITLE
Use the most recent boot image (specific sha)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,7 @@
 # This Containerfile is based on an ansible playbook for provisioning Copr builders
 # https://pagure.io/fedora-infra/ansible/blob/main/f/roles/copr/backend/files/provision/provision_builder_tasks.yml
 
-FROM quay.io/fedora/fedora-bootc:42
+FROM quay.io/fedora/fedora-bootc:42@sha256:837321f214a7d7e2ddc7296d9fedaf92141fce7b4daed8e4353a1754cb1f654f
 
 # Disable zram SWAP on builders, it is too small, issue 2077
 RUN dnf -y remove zram-generator-defaults && dnf -y clean all


### PR DESCRIPTION
This format ensures that we avoid race conditions; that is, even if we start the per-architecture MPC workers in Konflux at different times, we will still build architecture-specific images from the same base image.

Then, when we use this method, Renovate/MintMaker will keep us updated.