### PR TITLE
Follow symlinks when finding AMI image

### DIFF
--- a/copr-build-image-bootc.sh
+++ b/copr-build-image-bootc.sh
@@ -53,7 +53,7 @@ if [ "$BUILD_BOOTC" == true ]; then
         find output -name disk.qcow2
         ;;
     ami)
-        image=$(find output -name disk.raw)
+        image=$(find -L output -name disk.raw)
         mv "$image" "${image//.raw/.ami}"
         find output -name disk.ami
         ;;


### PR DESCRIPTION
In internal Copr we do this:

    ./prepare-worker
    mkdir /var/lib/containers/output
    ln -s /var/lib/containers/output ~/copr-image-builder/output

so we need to follow the symlink otherwise the image is not found