### PR TITLE
Update base image to latest f44

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -2,9 +2,6 @@
 # https://pagure.io/fedora-infra/ansible/blob/main/f/roles/copr/backend/files/provision/provision_builder_tasks.yml
 FROM quay.io/fedora/fedora-bootc:44@sha256:e3eaca476d25a47aec32f15fc5ee939a15a40d2cf163bc722d0a598d33558484
 
-# Disable zram SWAP on builders, it is too small, issue 2077
-RUN dnf -y remove zram-generator-defaults && dnf -y clean all
-
 # TODO work-around for wrongly generated ami
 # I guess we can remove this?
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,6 @@
 # This Containerfile is based on an ansible playbook for provisioning Copr builders
 # https://pagure.io/fedora-infra/ansible/blob/main/f/roles/copr/backend/files/provision/provision_builder_tasks.yml
-FROM quay.io/fedora/fedora-bootc:43@sha256:9aa313086c4d4c74e1aafd57792615fdce18e8f53519c9d88a284a8f85ce61ea
+FROM quay.io/fedora/fedora-bootc:44@sha256:e3eaca476d25a47aec32f15fc5ee939a15a40d2cf163bc722d0a598d33558484
 
 # Disable zram SWAP on builders, it is too small, issue 2077
 RUN dnf -y remove zram-generator-defaults && dnf -y clean all


### PR DESCRIPTION
```bash
$ skopeo inspect docker://quay.io/fedora/fedora-bootc:44 | jq -r '.Digest'
sha256:e3eaca476d25a47aec32f15fc5ee939a15a40d2cf163bc722d0a598d33558484
```

and

```
The `zram-generator-defaults` package is no longer included in the
fedora-bootc:44 base image, so it fails with dnf5.
The zram-generator engine is still installed but without the defaults
config package it does nothing -- no zram swap is created at boot.

Verified on all architectures:
  $ for arch in amd64 arm64 s390x ppc64le; do
      echo "=== $arch ==="
      podman run --rm -q --platform linux/$arch \
        quay.io/fedora/fedora-bootc:44 sh -c \
        'rpm -q zram-generator-defaults; rpm -q zram-generator;
         cat /usr/lib/systemd/zram-generator.conf 2>&1'
    done
  === amd64 ===
  package zram-generator-defaults is not installed
  zram-generator-1.2.1-5.fc44.x86_64
  cat: /usr/lib/systemd/zram-generator.conf: No such file or directory
  === arm64 ===
  package zram-generator-defaults is not installed
  zram-generator-1.2.1-5.fc44.aarch64
  cat: /usr/lib/systemd/zram-generator.conf: No such file or directory
  === s390x ===
  package zram-generator-defaults is not installed
  zram-generator-1.2.1-5.fc44.s390x
  cat: /usr/lib/systemd/zram-generator.conf: No such file or directory
  === ppc64le ===
  package zram-generator-defaults is not installed
  zram-generator-1.2.1-5.fc44.ppc64le
  cat: /usr/lib/systemd/zram-generator.conf: No such file or directory


This was breaking Konflux CI builds on s390x/ppc64le/aarch64.
```